### PR TITLE
feat: implement _update_terrain_curriculum and fix _get_env_origins for heightfield/trimesh

### DIFF
--- a/legged_gym/envs/base/legged_robot.py
+++ b/legged_gym/envs/base/legged_robot.py
@@ -142,6 +142,10 @@ class LeggedRobot(BaseTask):
 
         self._resample_commands(env_ids)
 
+        # update terrain curriculum before repositioning robots
+        if self.cfg.terrain.curriculum:
+            self._update_terrain_curriculum(env_ids)
+
         # reset buffers
         self.actions[env_ids] = 0.
         self.last_actions[env_ids] = 0.
@@ -154,6 +158,8 @@ class LeggedRobot(BaseTask):
         for key in self.episode_sums.keys():
             self.extras["episode"]['rew_' + key] = torch.mean(self.episode_sums[key][env_ids]) / self.max_episode_length_s
             self.episode_sums[key][env_ids] = 0.
+        if self.cfg.terrain.curriculum:
+            self.extras["episode"]["terrain_level"] = torch.mean(self.terrain_levels.float())
         if self.cfg.commands.curriculum:
             self.extras["episode"]["max_command_x"] = self.command_ranges["lin_vel_x"][1]
         # send timeout info to the algorithm
@@ -383,6 +389,45 @@ class LeggedRobot(BaseTask):
 
    
     
+    def _update_terrain_curriculum(self, env_ids):
+        """ Implements a curriculum of increasing terrain difficulty.
+
+        Robots that travel more than half the terrain-platform length during an
+        episode are promoted to the next harder difficulty level; robots that
+        fall short are demoted one level.  Terrain levels are clamped to
+        [0, num_rows - 1] so they never go out of bounds.  After updating the
+        level, each environment's world-space origin is refreshed from the
+        pre-computed terrain_origins lookup table.
+
+        This method is a no-op until after the first full reset (self.init_done),
+        so the very first episode always starts on the initialised level.
+
+        Args:
+            env_ids (List[int]): ids of environments being reset
+        """
+        if not self.init_done:
+            # Skip on the very first call — terrain_levels were set in _get_env_origins
+            return
+
+        # Measure how far each resetting robot moved from its terrain-platform centre
+        distance = torch.norm(
+            self.root_states[env_ids, :2] - self.env_origins[env_ids, :2], dim=1
+        )
+
+        # Promote if the robot covered more than half a platform length, else demote
+        move_up   = distance > self.terrain.env_length / 2
+        move_down = ~move_up
+
+        self.terrain_levels[env_ids] += move_up.long() - move_down.long()
+        self.terrain_levels[env_ids] = torch.clamp(
+            self.terrain_levels[env_ids], 0, self.cfg.terrain.num_rows - 1
+        )
+
+        # Update world origins for the reset environments
+        self.env_origins[env_ids] = self.terrain_origins[
+            self.terrain_levels[env_ids], self.terrain_types[env_ids]
+        ]
+
     def update_command_curriculum(self, env_ids):
         """ Implements a curriculum of increasing commands
 
@@ -608,17 +653,28 @@ class LeggedRobot(BaseTask):
         """ Sets environment origins. On rough terrain the origins are defined by the terrain platforms.
             Otherwise create a grid.
         """
-      
-        self.custom_origins = False
-        self.env_origins = torch.zeros(self.num_envs, 3, device=self.device, requires_grad=False)
-        # create a grid of robots
-        num_cols = np.floor(np.sqrt(self.num_envs))
-        num_rows = np.ceil(self.num_envs / num_cols)
-        xx, yy = torch.meshgrid(torch.arange(num_rows), torch.arange(num_cols))
-        spacing = self.cfg.env.env_spacing
-        self.env_origins[:, 0] = spacing * xx.flatten()[:self.num_envs]
-        self.env_origins[:, 1] = spacing * yy.flatten()[:self.num_envs]
-        self.env_origins[:, 2] = 0.
+        if self.cfg.terrain.mesh_type in ["heightfield", "trimesh"]:
+            self.custom_origins = True
+            self.env_origins = torch.zeros(self.num_envs, 3, device=self.device, requires_grad=False)
+            # Store terrain origins as a tensor for fast indexed lookup during curriculum updates
+            self.terrain_origins = torch.from_numpy(self.terrain.env_origins).to(self.device).to(torch.float)
+            # Assign each environment a terrain type (column) spread evenly across columns
+            self.terrain_types = torch.randint(0, self.cfg.terrain.num_cols, (self.num_envs,), device=self.device)
+            # Start all environments at a random level up to max_init_terrain_level
+            max_init = min(self.cfg.terrain.max_init_terrain_level, self.cfg.terrain.num_rows - 1)
+            self.terrain_levels = torch.randint(0, max_init + 1, (self.num_envs,), device=self.device)
+            self.env_origins[:] = self.terrain_origins[self.terrain_levels, self.terrain_types]
+        else:
+            self.custom_origins = False
+            self.env_origins = torch.zeros(self.num_envs, 3, device=self.device, requires_grad=False)
+            # create a grid of robots
+            num_cols = np.floor(np.sqrt(self.num_envs))
+            num_rows = np.ceil(self.num_envs / num_cols)
+            xx, yy = torch.meshgrid(torch.arange(num_rows), torch.arange(num_cols))
+            spacing = self.cfg.env.env_spacing
+            self.env_origins[:, 0] = spacing * xx.flatten()[:self.num_envs]
+            self.env_origins[:, 1] = spacing * yy.flatten()[:self.num_envs]
+            self.env_origins[:, 2] = 0.
 
     def _parse_cfg(self, cfg):
         self.dt = self.cfg.control.decimation * self.sim_params.dt


### PR DESCRIPTION
## Summary

Fixes #81

The `_update_terrain_curriculum(env_ids)` method was referenced in the docstring of `reset_idx` but was never implemented. With `cfg.terrain.curriculum = True` and a heightfield/trimesh terrain, the curriculum was silently a no-op — all robots stayed on the same terrain level forever.

This PR implements the full terrain curriculum loop in a single file (`legged_gym/envs/base/legged_robot.py`).

---

## Changes

### `_get_env_origins()` — heightfield/trimesh branch

Previously the method always created a flat grid and left `custom_origins = False`, so robots were never actually placed on the heightfield platforms. Now:

- Sets `custom_origins = True` for `heightfield` and `trimesh` mesh types.
- Converts `terrain.env_origins` (numpy array, shape `[num_rows, num_cols, 3]`) to a GPU tensor `self.terrain_origins` for fast indexed lookups.
- Assigns each environment a random terrain **type** (column index).
- Initialises each environment to a random **level** (row index) in `[0, max_init_terrain_level]`.
- Populates `self.env_origins` from the lookup table immediately.

### `_update_terrain_curriculum(env_ids)` — new method

Called at the start of each `reset_idx` when `cfg.terrain.curriculum` is `True`:

1. Computes how far each resetting robot moved from its terrain-platform centre (XY distance).
2. Promotes robots that covered **> half a platform length** (`env_length / 2`) to the next harder level.
3. Demotes robots that fell short by one level.
4. Clamps all levels to `[0, num_rows - 1]`.
5. Refreshes `self.env_origins[env_ids]` from the `terrain_origins` lookup table so that `_reset_root_states` places the robot on the correct platform.

The method is a no-op until `self.init_done` is set, preserving the initial level assignment from `_get_env_origins`.

### `reset_idx()` — wired up

- Calls `_update_terrain_curriculum(env_ids)` before robot repositioning when `cfg.terrain.curriculum` is `True`.
- Logs `extras["episode"]["terrain_level"]` (mean across all envs) for training curve monitoring.

## Test plan

- [ ] Set `cfg.terrain.mesh_type = 'heightfield'` and `cfg.terrain.curriculum = True`, train a G1/H1 policy — confirm robots spawn on terrain platforms and `terrain_level` in tensorboard increases over training.
- [ ] Set `cfg.terrain.mesh_type = 'plane'` — confirm flat-grid path is unchanged.
- [ ] Set `cfg.terrain.curriculum = False` with heightfield — confirm `_update_terrain_curriculum` is never called and robots still spawn correctly.