### PR TITLE
fix: replace incorrect .qd with .dq in motor commands (deploy_real.py)

### DIFF
--- a/deploy/deploy_real/deploy_real.py
+++ b/deploy/deploy_real/deploy_real.py
@@ -122,7 +122,7 @@ class Controller:
                 motor_idx = dof_idx[j]
                 target_pos = default_pos[j]
                 self.low_cmd.motor_cmd[motor_idx].q = init_dof_pos[j] * (1 - alpha) + target_pos * alpha
-                self.low_cmd.motor_cmd[motor_idx].qd = 0
+                self.low_cmd.motor_cmd[motor_idx].dq = 0
                 self.low_cmd.motor_cmd[motor_idx].kp = kps[j]
                 self.low_cmd.motor_cmd[motor_idx].kd = kds[j]
                 self.low_cmd.motor_cmd[motor_idx].tau = 0
@@ -136,14 +136,14 @@ class Controller:
             for i in range(len(self.config.leg_joint2motor_idx)):
                 motor_idx = self.config.leg_joint2motor_idx[i]
                 self.low_cmd.motor_cmd[motor_idx].q = self.config.default_angles[i]
-                self.low_cmd.motor_cmd[motor_idx].qd = 0
+                self.low_cmd.motor_cmd[motor_idx].dq = 0
                 self.low_cmd.motor_cmd[motor_idx].kp = self.config.kps[i]
                 self.low_cmd.motor_cmd[motor_idx].kd = self.config.kds[i]
                 self.low_cmd.motor_cmd[motor_idx].tau = 0
             for i in range(len(self.config.arm_waist_joint2motor_idx)):
                 motor_idx = self.config.arm_waist_joint2motor_idx[i]
                 self.low_cmd.motor_cmd[motor_idx].q = self.config.arm_waist_target[i]
-                self.low_cmd.motor_cmd[motor_idx].qd = 0
+                self.low_cmd.motor_cmd[motor_idx].dq = 0
                 self.low_cmd.motor_cmd[motor_idx].kp = self.config.arm_waist_kps[i]
                 self.low_cmd.motor_cmd[motor_idx].kd = self.config.arm_waist_kds[i]
                 self.low_cmd.motor_cmd[motor_idx].tau = 0
@@ -206,7 +206,7 @@ class Controller:
         for i in range(len(self.config.leg_joint2motor_idx)):
             motor_idx = self.config.leg_joint2motor_idx[i]
             self.low_cmd.motor_cmd[motor_idx].q = target_dof_pos[i]
-            self.low_cmd.motor_cmd[motor_idx].qd = 0
+            self.low_cmd.motor_cmd[motor_idx].dq = 0
             self.low_cmd.motor_cmd[motor_idx].kp = self.config.kps[i]
             self.low_cmd.motor_cmd[motor_idx].kd = self.config.kds[i]
             self.low_cmd.motor_cmd[motor_idx].tau = 0
@@ -214,7 +214,7 @@ class Controller:
         for i in range(len(self.config.arm_waist_joint2motor_idx)):
             motor_idx = self.config.arm_waist_joint2motor_idx[i]
             self.low_cmd.motor_cmd[motor_idx].q = self.config.arm_waist_target[i]
-            self.low_cmd.motor_cmd[motor_idx].qd = 0
+            self.low_cmd.motor_cmd[motor_idx].dq = 0
             self.low_cmd.motor_cmd[motor_idx].kp = self.config.arm_waist_kps[i]
             self.low_cmd.motor_cmd[motor_idx].kd = self.config.arm_waist_kds[i]
             self.low_cmd.motor_cmd[motor_idx].tau = 0


### PR DESCRIPTION
## Summary

Fixes #61

The `MotorCmd` struct field for desired joint velocity is named `dq`, not `qd`. All five occurrences in `deploy_real.py` were using the wrong field name:

```python
# Before (incorrect)
self.low_cmd.motor_cmd[motor_idx].qd = 0

# After (correct)
self.low_cmd.motor_cmd[motor_idx].dq = 0
```

### Affected lines
| Line | Location |
|------|----------|
| 125 | `move_to_default_pos()` — leg joints interpolation loop |
| 139 | `default_pos_state()` — leg joints hold loop |
| 146 | `default_pos_state()` — arm/waist joints hold loop |
| 209 | `run()` — leg joints command build |
| 217 | `run()` — arm/waist joints command build |

### Impact
Using `.qd` silently assigns to a non-existent (or unintended) attribute on the `MotorCmd` object, so the desired joint velocity is **never actually zeroed out** during deployment. This can cause unexpected motor behavior on real hardware.

## Test plan
- [ ] Verify `MotorCmd` field name against `unitree_sdk2_python` IDL definition (`dq` is correct)
- [ ] Deploy with corrected script and confirm motors respond as expected